### PR TITLE
Feature/add this overlapping homescreen

### DIFF
--- a/src/components/HomeScreenPrompt/HomeScreenPrompt.scss
+++ b/src/components/HomeScreenPrompt/HomeScreenPrompt.scss
@@ -9,7 +9,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 999;
+  z-index: 1000300;
   transform: translateY(100%);
   padding: space(16);
   background-color: $mercury;

--- a/src/components/HomeScreenPrompt/InstructionModal/InstructionModal.tsx
+++ b/src/components/HomeScreenPrompt/InstructionModal/InstructionModal.tsx
@@ -31,6 +31,11 @@ class InstructionModal extends Component<any> {
         className="modal instruction-modal"
         shouldCloseOnEsc={true}
         shouldCloseOnOverlayClick={true}
+        style={{
+          overlay: {
+            zIndex: 100003000
+          }
+        }}
       >
         <div className="instruction-modal__main">
           <div className="instruction-modal__close">


### PR DESCRIPTION
### Summary
https://trello.com/c/rPlW9n0U/188-bug-addthis-overlapping-homescreen-icon-on-mobile

The add this module was overlapping the home screen prompt as it had a higher z-index, this PR is too fix this issue.

### Development checklist
- [ ] The home screen prompt should appear above the add this module on mobile.
- [ ] The instruction modal that is access from the home screen prompt should appear above the add this module on mobile.

### Release checklist
N/A

### Notes
N/A
