### PR TITLE
Amended Referall card logic to accpet external referral method

### DIFF
--- a/src/views/Service/ReferralCard/ReferralCard.tsx
+++ b/src/views/Service/ReferralCard/ReferralCard.tsx
@@ -4,18 +4,19 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Button from '../../../components/Button';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { observer } from 'mobx-react';
+import { IService } from '../../../types/types';
 
 interface IProps extends RouteComponentProps {
-  id: string;
+  service: IService;
 }
 
-const ReferralCard: React.FunctionComponent<IProps> = ({ history, id }) => (
+const ReferralCard: React.FunctionComponent<IProps> = ({ history, service }) => (
   <div className="flex-container flex-container--align-center flex-container--justify flex-container--mobile-no-padding service__referral">
     <div className="flex-col flex-col--tablet--6 flex-col--mobile--12 flex-col--mobile-small--12">
       <Button
         text="Make a connection"
         icon="arrow-right"
-        onClick={() => history.push(`/referral?service=${id}`)}
+        onClick={() => service.referral_method === 'external' ? window.open(`${service.referral_url}`) : history.push(`/referral?service=${service.id}`) } 
       />
     </div>
     <div className="flex-col flex-col--tablet--12">

--- a/src/views/Service/Service.tsx
+++ b/src/views/Service/Service.tsx
@@ -353,7 +353,7 @@ class Service extends Component<IProps> {
 
                   {service.referral_method !== 'none' && (
                     <div className="mobile-show">
-                      <ReferralCard id={service.id} />
+                      <ReferralCard service={service} />
                     </div>
                   )}
 
@@ -433,7 +433,7 @@ class Service extends Component<IProps> {
                     <h2>{`How can I contact this ${service.type}?`}</h2>
                     {service.referral_method !== 'none' && (
                       <div className="service__section service__referral--desktop">
-                        <ReferralCard id={service.id} />
+                        <ReferralCard service={service} />
                       </div>
                     )}
                     <div className="service__section">


### PR DESCRIPTION
### Summary
https://trello.com/c/nVVNTG9p/191-bug-referal-method-external-not-working

The service inner should now have conditional logic applied to the referral button for external referrals

### Development checklist
- [x] If a service has their referral method set to external, the make a connection button should now open the referral_url in a new window
- [x] If the referral method is set internal it should take the user through the referral process on the app as before
- [x] If none is set for the referral method the button should not show

### Release checklist
N/A

### Notes
N/A
